### PR TITLE
Adding button to check only one participant as paid at a time

### DIFF
--- a/src/app/home/RaffleProperties.ts
+++ b/src/app/home/RaffleProperties.ts
@@ -9,6 +9,7 @@ export class RaffleProperties {
   public inOrderMode: boolean;
   public lastUpdated: Date;
   public escrowBotCalled: boolean;
+  public allSpotsPaidMode: boolean;
 
   constructor() {
     this.customFlair = '';
@@ -21,5 +22,6 @@ export class RaffleProperties {
     this.inOrderMode = false;
     this.lastUpdated;
     this.escrowBotCalled = false;
+    this.allSpotsPaidMode = true;
   }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -272,6 +272,16 @@
               (change)="updateRaffleProperties()"
             />
           </div>
+          <div class="col-xs-3">
+            <label for="">All Spots Paid Mode?</label>
+            <input
+              type="checkbox"
+              id="allSpotsPaidMode"
+              name="allSpotsPaidMode"
+              [(ngModel)]="raffleProperties.allSpotsPaidMode"
+              (change)="updateRaffleProperties()"
+            />
+          </div>
           <div class="col-xs-12" style="height:10px;"></div>
         </div>
 
@@ -392,7 +402,7 @@
               "
               [(ngModel)]="raffleParticipant.paid"
               (change)="
-                updateAffectedSlots(raffleParticipant.name, $event);
+                updateAffectedSlots(raffleParticipant.name, $event, i);
                 paidPopOver.toggle($event)
               "
             />

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -645,14 +645,24 @@ export class HomeComponent implements OnInit {
     }
   }
 
-  private updateAffectedSlots(name: string, event: any) {
+  private updateAffectedSlots(name: string, event: any, i:  number) {
     this.hasPmsToProcess = false;
     let numAffected = 1;
 
     this.closePopOver = false;
 
-    for (let x = 0; x < this.raffleParticipants.length; x++) {
-      const raffler = this.raffleParticipants[x];
+    if (this.raffleProperties.allSpotsPaidMode) {
+      for (let x = 0; x < this.raffleParticipants.length; x++) {
+        const raffler = this.raffleParticipants[x];
+        if (raffler.name && raffler.name.toUpperCase() === name.toUpperCase()) {
+          if (raffler.paid !== event.target.checked) {
+            raffler.paid = event.target.checked;
+            numAffected++;
+          }
+        }
+      }
+    } else {
+      const raffler = this.raffleParticipants[i];
       if (raffler.name && raffler.name.toUpperCase() === name.toUpperCase()) {
         if (raffler.paid !== event.target.checked) {
           raffler.paid = event.target.checked;


### PR DESCRIPTION
This PR is meant to add a feature so that rafflers can mark each number as paid or not as opposed to always marking all spots of a participant to be paid or unpaid.